### PR TITLE
Fix manifest for case-sensitive filesystems

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
             "background/domSelectorReport.js",
             "background/webNavigator.js",
             "background/debuggerControls.js",
-            "background/keyboardControls.js",
+            "background/keyBoardControls.js",
             "background/tabControls.js",
             "background/background.js"
         ]


### PR DESCRIPTION
The file is named `background/keyBoardControls.js` whereas the manifest refers it as `background/keyboardControls.js`. This is fine for case-insensitive filesystems such as NTFS (Windows) or default HFS (MacOS), but the installation of the plugin will fail on case-sensitive filesystems, which is the default on Linux.

This commit fixes the issue by changing the case in the manifest.